### PR TITLE
Bug fix for stravalib==0.9 on pip >= 10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ celery
 redis
 flask-wtf
 flask-sqlalchemy
+pip-tools
 stravalib==0.9


### PR DESCRIPTION
stravalib==0.9 contains in the setup file this import:
`from pip.req import parse_requirements`
But starting from pip >= 10 the module is called `pip._internal.req` instead of `pip.req`.

A (not recommended) workaround is to downgrade pip to v9 with `python -m pip install pip==9.0.3`.

The solution is to install (or update to the latest version) `pip-tools`.
I have added it to requirements.txt, so that the dependency installation will work without any additional work required.

More information on [this Stack Overflow thread](https://stackoverflow.com/questions/25192794/no-module-named-pip-req/49867265).